### PR TITLE
Implement Command Line

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Hachigo is a simple CHIP-8 emulator. It's equipped with SDL as the user interfac
 
 ## Usage
 
-To run:
+To run using non-original behavior:
 ```bash
-go run .
+$ go run . -f <filepath>
+```
+
+To view the usage of optional flags:
+```bash
+$ go run . -h
+```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,12 @@ To run using non-original behavior:
 $ go run . -f <filepath>
 ```
 
-To view the usage of optional flags:
+To run using original behavior:
+```bash
+$ go run . -f <filepath> -o
+```
+
+To view the usage of other optional flags:
 ```bash
 $ go run . -h
 ```

--- a/main.go
+++ b/main.go
@@ -69,12 +69,22 @@ var eightxy6Flag flagStruct = flagStruct{name: "8xy6"}
 var eightxyeFlag flagStruct = flagStruct{name: "8xye"}
 var fx55Flag flagStruct = flagStruct{name: "fx55"}
 var fx65Flag flagStruct = flagStruct{name: "fx65"}
+var fileFlag *string
 
 // ignore the memory clock atm
 func main() {
+	flags()
+	loadFileToMemory(&memory, *fileFlag)
+	go chip()
+	k.SetIsPressed(false)
+	sound.InitSound()
+	display.InitDisplay()
+}
+
+func flags() {
 	var overrideFlags []*flagStruct
 	flagSet := make(map[string]bool)
-	fileFlag := flag.String("f", "", "filepath of chip8 program (.ch8 file)")
+	fileFlag = flag.String("f", "", "filepath of chip8 program (.ch8 file)")
 	isOriginal.value = flag.Bool(isOriginal.name, false, "set to original cosmacvip behavior (using original behavior if specified)")
 	bnnnFlag.value = flag.Bool(bnnnFlag.name, false, "override bnnn instruction (using original behavior if specified)")
 	eightxy6Flag.value = flag.Bool(eightxy6Flag.name, false, "override 8xy6 instruction (using original behavior if specified)")
@@ -106,12 +116,6 @@ func main() {
 			f.value = isOriginal.value
 		}
 	}
-
-	loadFileToMemory(&memory, *fileFlag)
-	go chip()
-	k.SetIsPressed(false)
-	sound.InitSound()
-	display.InitDisplay()
 }
 
 func chip() {

--- a/main.go
+++ b/main.go
@@ -70,8 +70,8 @@ var eightxyeFlag flagStruct = flagStruct{name: "8xye"}
 var fx55Flag flagStruct = flagStruct{name: "fx55"}
 var fx65Flag flagStruct = flagStruct{name: "fx65"}
 var fileFlag *string
+var clockFlag *int
 
-// ignore the memory clock atm
 func main() {
 	flags()
 	loadFileToMemory(&memory, *fileFlag)
@@ -85,6 +85,7 @@ func flags() {
 	var overrideFlags []*flagStruct
 	flagSet := make(map[string]bool)
 	fileFlag = flag.String("f", "", "filepath of chip8 program (.ch8 file)")
+	clockFlag = flag.Int("c", 500, "set clockspeed, in Hz (defaulted to 500 Hz)")
 	isOriginal.value = flag.Bool(isOriginal.name, false, "set to original cosmacvip behavior (using original behavior if specified)")
 	bnnnFlag.value = flag.Bool(bnnnFlag.name, false, "override bnnn instruction (using original behavior if specified)")
 	eightxy6Flag.value = flag.Bool(eightxy6Flag.name, false, "override 8xy6 instruction (using original behavior if specified)")
@@ -99,14 +100,15 @@ func flags() {
 	overrideFlags = append(overrideFlags, &fx65Flag)
 
 	flag.Parse()
-	flag.Visit(func(f *flag.Flag) {
-		flagSet[f.Name] = true
-	})
 
 	if len(*fileFlag) < 1 {
 		fmt.Println("Need to specify filepath using -f flag!")
 		return
 	}
+
+	flag.Visit(func(f *flag.Flag) {
+		flagSet[f.Name] = true
+	})
 
 	for i := range overrideFlags {
 		f := overrideFlags[i]
@@ -394,7 +396,7 @@ func chip() {
 		default:
 			fmt.Printf("unsupported instruction: %X\n", instruction)
 		}
-		time.Sleep(time.Second / 2500)
+		time.Sleep(time.Second / time.Duration(*clockFlag))
 	}
 }
 


### PR DESCRIPTION
Flags:
- `-f` set filepath (mandatory, no default)
- `c` clock speed (defaulted to 500 Hz)
- `-o` run the original behavior (will set to true if specified, otherwise will set to false)
- `-bnnn` override BNNN behavior, will use original behavior if specified (defaulted to false)
- `-fx55` override FX55 behavior, will use original behavior if specified (defaulted to false)
- `-fx65` override FX65 behavior, will use original behavior if specified (defaulted to false)
- `-8xy6` override 8XY6 behavior, will use original behavior if specified (defaulted to false)
- `-8xye` override 8XYE behavior, will use original behavior if specified (defaulted to false)